### PR TITLE
Allow the Library to be Configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,5 @@ ruby "3.1.2"
 gemspec
 
 gem "rake", "~> 13.0"
-
 gem "rspec", "~> 3.0"
-
 gem "rubocop", "1.22.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    coderay (1.1.3)
     diff-lcs (1.5.0)
+    json (2.6.3)
+    method_source (1.0.0)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.7.0)
@@ -47,6 +53,7 @@ PLATFORMS
 
 DEPENDENCIES
   intelligent_foods!
+  pry (~> 0.14)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (= 1.22.1)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # IntelligentFoods
 
-Welcome to your new gem! In this directory, you'll find the files you need to
-be able to package up your Ruby library into a gem. Put your Ruby code in the
-file `lib/intelligent_foods`. To experiment with that code, run `bin/console`
-for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
-
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
@@ -18,9 +11,28 @@ executing:
 
     $ gem install intelligent-foods-ruby
 
-## Usage
+## Getting Started
 
-TODO: Write usage instructions here
+### Setup Work
+
+```
+require "intelligent-foods-ruby"
+
+IntelligentFoods.configure do |config|
+  config.client_id = "XXXXXX"
+  config.client_secret = "YYYYYY"
+  config.environment = "preview"
+end
+```
+
+### Authentication
+
+```
+@client = IntelligentFoods.client
+@client.authenticate!
+```
+
+### Usage
 
 ## Development
 

--- a/intelligent-foods-ruby.gemspec
+++ b/intelligent-foods-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Ruby SDK for the Intelligent Foods API"
   spec.homepage = "https://intelligentfoods.com"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
+
+  spec.add_development_dependency "pry", "~> 0.14"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -1,8 +1,54 @@
 # frozen_string_literal: true
 
-require_relative "intelligent_foods/version"
+require "base64"
+require "json"
+require "net/http"
+require "ostruct"
+
+require "intelligent_foods/version"
+require "intelligent_foods/api_client"
 
 module IntelligentFoods
   class Error < StandardError; end
 
+  class << self
+    attr_accessor :client_id, :client_secret, :environment
+
+    def configure
+      yield self
+      configure_enviroment
+    end
+
+    def base_auth_url
+      @base_auth_url = "https://#{auth_domain}.auth.us-west-2.amazoncognito.com"
+    end
+
+    def base_url
+      @base_url = "https://api.#{domain}.com/partner/v1"
+    end
+
+    def client
+      @client ||=
+        IntelligentFoods::ApiClient.new(id: client_id, secret: client_secret)
+    end
+
+    protected
+
+    attr_reader :domain, :auth_domain
+
+    def configure_enviroment
+      case environment
+      when "production"
+        @auth_domain = "sunbasket-partner"
+        @domain = "sunbasket"
+      when "staging"
+        @auth_domain = "sunbasket-partner-staging"
+        @domain = "sunbasket-staging"
+      else
+        @auth_domain = "sunbasket-partner-dev"
+        @domain = "sunbasket-dev"
+      end
+    end
+
+  end
 end

--- a/lib/intelligent_foods/api_client.rb
+++ b/lib/intelligent_foods/api_client.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class ApiClient
+    attr_reader :id, :secret, :access_token
+
+    def initialize(id: nil, secret: nil, client: nil)
+      @id = id
+      @secret = secret
+      @client = client || Net::HTTP
+      @encoded_token = Base64.strict_encode64("#{id}:#{secret}")
+    end
+
+    def authenticate!
+      initialize_request
+      assign_request_headers
+      assign_request_body
+      perform_request
+      extract_access_token
+      nil
+    end
+
+    protected
+
+    attr_reader :encoded_token, :request, :response, :uri
+
+    def initialize_request
+      @uri = URI("#{IntelligentFoods.base_auth_url}/oauth2/token")
+      @request = Net::HTTP::Post.new(uri)
+    end
+
+    def assign_request_headers
+      request["content-type"] = "application/x-www-form-urlencoded"
+      request["Authorization"] = "Basic #{encoded_token}"
+    end
+
+    def assign_request_body
+      request.set_form_data("grant_type" => "client_credentials")
+    end
+
+    def perform_request
+      @response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        response = http.request(request)
+        JSON.parse(response.body, symbolize_names: true)
+      end
+    end
+
+    def extract_access_token
+      if response.has_key? :errors
+        handle_errors response[:errors]
+      else
+        @access_token = response[:access_token]
+      end
+    end
+
+    def handle_errors(errors)
+      fail IntelligentFoods::Error.new(errors.first)
+    end
+  end
+end

--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe IntelligentFoods::ApiClient do
+  describe "#authenticate!" do
+    it "sets the access token" do
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+      access_token = "accesstoken"
+      stub_authentication access_token: access_token
+
+      client.authenticate!
+
+      expect(client.access_token).to eq(access_token)
+    end
+
+    it "sets the content type header" do
+      stub_authentication
+      request = build_stubbed_post
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+      content_type = "application/x-www-form-urlencoded"
+
+      client.authenticate!
+
+      expect(request["content-type"]).to eq(content_type)
+    end
+
+    it "sets the authorization header" do
+      stub_authentication
+      request = build_stubbed_post
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+      header = "Basic #{build_encoded_token(id: "id", secret: "secret")}"
+
+      client.authenticate!
+
+      expect(request["Authorization"]).to eq(header)
+    end
+
+    it "sets the request body" do
+      stub_authentication
+      request = build_stubbed_post
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+
+      client.authenticate!
+
+      expect(request.body).to eq("grant_type=client_credentials")
+    end
+
+    context "there is an error with the request" do
+      it "raises an error" do
+        response = error_response(message: "Could not perform request")
+        stub_api_response response: response
+        client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+
+        expect {
+          client.authenticate!
+        }.to raise_error("Could not perform request")
+      end
+    end
+  end
+end

--- a/spec/intelligent_foods_spec.rb
+++ b/spec/intelligent_foods_spec.rb
@@ -4,4 +4,140 @@ RSpec.describe IntelligentFoods do
   it "has a version number" do
     expect(IntelligentFoods::VERSION).not_to be_nil
   end
+
+  describe "#configure" do
+    it "sets the client ID" do
+      IntelligentFoods.configure do |config|
+        config.client_id = "abc"
+      end
+
+      expect(IntelligentFoods.client_id).to eq("abc")
+    end
+
+    it "sets the client secret" do
+      IntelligentFoods.configure do |config|
+        config.client_secret = "abc"
+      end
+
+      expect(IntelligentFoods.client_secret).to eq("abc")
+    end
+
+    it "sets the environment" do
+      IntelligentFoods.configure do |config|
+        config.environment = "preview"
+      end
+
+      expect(IntelligentFoods.environment).to eq("preview")
+    end
+  end
+
+  describe "#base_url" do
+    context "environment is preview" do
+      it "returns the correct url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "preview"
+        end
+        preview_url = "https://api.sunbasket-dev.com/partner/v1"
+
+        expect(IntelligentFoods.base_url).to eq(preview_url)
+      end
+    end
+
+    context "environment is staging" do
+      it "returns the correct url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "staging"
+        end
+        staging_url = "https://api.sunbasket-staging.com/partner/v1"
+
+        expect(IntelligentFoods.base_url).to eq(staging_url)
+      end
+    end
+
+    context "environment is production" do
+      it "returns the correct url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "production"
+        end
+        production_url = "https://api.sunbasket.com/partner/v1"
+
+        expect(IntelligentFoods.base_url).to eq(production_url)
+      end
+    end
+
+    context "environment is not any of the above" do
+      it "defaults to the dev url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "asdf"
+        end
+        preview_url = "https://api.sunbasket-dev.com/partner/v1"
+
+        expect(IntelligentFoods.base_url).to eq(preview_url)
+      end
+    end
+  end
+
+  describe "#base_auth_url" do
+    context "environment is preview" do
+      it "returns the correct url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "preview"
+        end
+        preview_url =
+          "https://sunbasket-partner-dev.auth.us-west-2.amazoncognito.com"
+
+        expect(IntelligentFoods.base_auth_url).to eq(preview_url)
+      end
+    end
+
+    context "environment is staging" do
+      it "returns the correct url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "staging"
+        end
+        staging_url =
+          "https://sunbasket-partner-staging.auth.us-west-2.amazoncognito.com"
+
+        expect(IntelligentFoods.base_auth_url).to eq(staging_url)
+      end
+    end
+
+    context "environment is production" do
+      it "returns the correct url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "production"
+        end
+        production_url =
+          "https://sunbasket-partner.auth.us-west-2.amazoncognito.com"
+
+        expect(IntelligentFoods.base_auth_url).to eq(production_url)
+      end
+    end
+
+    context "environment is not any of the above" do
+      it "defaults to the dev url" do
+        IntelligentFoods.configure do |config|
+          config.environment = "asdf"
+        end
+        preview_url =
+          "https://sunbasket-partner-dev.auth.us-west-2.amazoncognito.com"
+
+        expect(IntelligentFoods.base_auth_url).to eq(preview_url)
+      end
+    end
+  end
+
+  describe "#client" do
+    it "returns an instance of the api client" do
+      IntelligentFoods.configure do |config|
+        config.client_id = "abc123"
+        config.client_secret = "xyz890"
+      end
+
+      result = IntelligentFoods.client
+
+      expect(result.id).to eq("abc123")
+      expect(result.secret).to eq("xyz890")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "pry"
 require "intelligent_foods"
+
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,4 +15,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include ApiHelper
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -1,0 +1,33 @@
+module ApiHelper
+  def authentication_response(access_token:)
+    build_response body: { access_token: access_token }
+  end
+
+  def error_response(message: "Unknown error")
+    build_response body: { errors: [message] }
+  end
+
+  def stub_authentication(access_token: "indifferenttoken")
+    response = authentication_response(access_token: access_token)
+    stub_api_response response: response
+  end
+
+  def stub_api_response(response:, http: double)
+    allow(Net::HTTP).to receive(:start).and_yield(http)
+    allow(http).to receive(:request).and_return(response)
+  end
+
+  def build_stubbed_post(url: "example.com")
+    request = Net::HTTP::Post.new(url)
+    allow(Net::HTTP::Post).to receive(:new).and_return(request)
+    request
+  end
+
+  def build_response(body:)
+    OpenStruct.new(body: JSON.generate(body))
+  end
+
+  def build_encoded_token(id:, secret:)
+    Base64.strict_encode64("#{id}:#{secret}")
+  end
+end


### PR DESCRIPTION
When using this library, we need to be able to set the data that is
required for connecting to and authenticating with the API.

This change addresses the need by:
* Setting the client_id, client_secret, and environment
* Building the correct authentication url
* Instantiating the API Client