### PR TITLE
Configure Rubocop

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,5 @@
 fail_on_violations: true
-ruby:
+
+rubocop:
   config_file: .rubocop.yml
+  version: 1.22.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
+  SuggestExtensions: false
   Include:
     - "**/Rakefile"
     - "**/config.ru"
@@ -10,6 +11,7 @@ AllCops:
     - "vendor/bundle/**/*"
     - "config/**/*"
     - "script/**/*"
+  NewCops: enable
 
 Layout/ConditionPosition:
   Enabled: false
@@ -39,7 +41,7 @@ Layout/ExtraSpacing:
 Layout/InitialIndentation:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 80
   Exclude:
     - "**/Gemfile"
@@ -211,7 +213,7 @@ Style/Encoding:
 Style/EvenOdd:
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Enabled: false
 
 Style/FormatString:
@@ -291,7 +293,7 @@ Style/RaiseArgs:
 Style/RegexpLiteral:
   Enabled: false
 
-Performance/Sample:
+Style/Sample:
   Enabled: false
 
 Style/SelfAssignment:
@@ -323,21 +325,21 @@ Style/SymbolArray:
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+ruby "3.1.2"
+
 # Specify your gem's dependencies in intelligent-foods-ruby.gemspec
 gemspec
 
@@ -9,4 +11,4 @@ gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
 
-gem "rubocop", "~> 1.21"
+gem "rubocop", "1.22.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
-    json (2.6.3)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
@@ -29,17 +28,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.48.0)
-      json (~> 2.3)
+    rubocop (1.22.1)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      rexml
+      rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.27.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.4.2)
@@ -51,7 +49,10 @@ DEPENDENCIES
   intelligent_foods!
   rake (~> 13.0)
   rspec (~> 3.0)
-  rubocop (~> 1.21)
+  rubocop (= 1.22.1)
+
+RUBY VERSION
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.3.17


### PR DESCRIPTION
This change addresses the need by:
* Setting the Rubocop version in Hound
* Updating the Rubcop configuration

http://help.houndci.com/en/articles/2461415-supported-linters