### PR TITLE
Introduce Menu Resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "1.22.1"
+gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     coderay (1.1.3)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.5.0)
-    json (2.6.3)
+    hashdiff (1.0.1)
     method_source (1.0.0)
     parallel (1.22.1)
     parser (3.2.1.1)
@@ -17,6 +21,7 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (5.0.1)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.7.0)
@@ -47,6 +52,10 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (2.4.2)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -57,6 +66,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (= 1.22.1)
+  webmock
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -5,8 +5,9 @@ require "json"
 require "net/http"
 require "ostruct"
 
-require "intelligent_foods/version"
 require "intelligent_foods/api_client"
+require "intelligent_foods/resources/menu"
+require "intelligent_foods/version"
 
 module IntelligentFoods
   class Error < StandardError; end

--- a/lib/intelligent_foods/api_client.rb
+++ b/lib/intelligent_foods/api_client.rb
@@ -12,40 +12,35 @@ module IntelligentFoods
     end
 
     def authenticate!
-      initialize_request
-      assign_request_headers
-      assign_request_body
-      perform_request
-      extract_access_token
-      nil
+      uri = URI("#{IntelligentFoods.base_auth_url}/oauth2/token")
+      request = Net::HTTP::Post.new(uri)
+      request["content-type"] = "application/x-www-form-urlencoded"
+      body = { "grant_type" => "client_credentials" }
+      response = execute_request(request: request, uri: uri, body: body)
+      extract_access_token response: response.data
+      self
+    end
+
+    def execute_request(request:, uri:, body: nil)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        request["Authorization"] = "Basic #{encoded_token}"
+        assign_body request: request, body: body
+        response = http.request(request)
+        OpenStruct.new(data: JSON.parse(response.body, symbolize_names: true),
+                       success?: response.code.to_i < 400)
+      end
     end
 
     protected
 
     attr_reader :encoded_token, :request, :response, :uri
 
-    def initialize_request
-      @uri = URI("#{IntelligentFoods.base_auth_url}/oauth2/token")
-      @request = Net::HTTP::Post.new(uri)
+    def assign_body(request:, body:)
+      return if body.nil?
+      request.set_form_data(body)
     end
 
-    def assign_request_headers
-      request["content-type"] = "application/x-www-form-urlencoded"
-      request["Authorization"] = "Basic #{encoded_token}"
-    end
-
-    def assign_request_body
-      request.set_form_data("grant_type" => "client_credentials")
-    end
-
-    def perform_request
-      @response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-        response = http.request(request)
-        JSON.parse(response.body, symbolize_names: true)
-      end
-    end
-
-    def extract_access_token
+    def extract_access_token(response:)
       if response.has_key? :errors
         handle_errors response[:errors]
       else

--- a/lib/intelligent_foods/resources/menu.rb
+++ b/lib/intelligent_foods/resources/menu.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class Menu
+    attr_accessor :id
+
+    def initialize(id: nil)
+      @id = id
+    end
+
+    def self.all
+      uri = URI("#{IntelligentFoods.base_url}/menus")
+      request = Net::HTTP::Get.new(uri)
+      client = IntelligentFoods.client
+      response = client.execute_request(request: request, uri: uri)
+      if response.success?
+        response.data.map { |id| IntelligentFoods::Menu.new(id: id) }
+      else
+        []
+      end
+    end
+  end
+end

--- a/spec/intelligent_foods/resources/menu_spec.rb
+++ b/spec/intelligent_foods/resources/menu_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe IntelligentFoods::Menu do
+  describe ".all" do
+    it "returns the menus" do
+      menu_ids = ["2023-03-12"]
+      response = build_response(body: menu_ids)
+      stub_api_response response: response
+
+      result = IntelligentFoods::Menu.all
+
+      expect(result.map(&:id)).to eq(menu_ids)
+    end
+
+    context "the response code is not 200" do
+      it "returns an empty array" do
+        body = { errors: ["Could not perform request"] }
+        response = build_response(body: body, http_status_code: 400)
+        stub_api_response response: response
+
+        result = IntelligentFoods::Menu.all
+
+        expect(result).to be_empty
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "pry"
 require "intelligent_foods"
+require "webmock"
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
@@ -18,3 +19,5 @@ RSpec.configure do |config|
 
   config.include ApiHelper
 end
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -12,7 +12,7 @@ module ApiHelper
     stub_api_response response: response
   end
 
-  def stub_api_response(response:, http: double)
+  def stub_api_response(response: OpenStruct.new(body: "{}"), http: double)
     allow(Net::HTTP).to receive(:start).and_yield(http)
     allow(http).to receive(:request).and_return(response)
   end
@@ -23,8 +23,8 @@ module ApiHelper
     request
   end
 
-  def build_response(body:)
-    OpenStruct.new(body: JSON.generate(body))
+  def build_response(body: {}, http_status_code: 200)
+    OpenStruct.new(body: JSON.generate(body), code: http_status_code)
   end
 
   def build_encoded_token(id:, secret:)


### PR DESCRIPTION
One of the first endpoints that will be accessed is the menus endpoint.
This introduces a Menu resource that can be used to get a listing of
all of the available menus.

This change addresses the need by:
* Improving the ApiClient class to handle executing any request
  against the API
* Adding the Menu resource with a standard `.all` method