### PR TITLE
Fix methods name spelling

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -17,7 +17,7 @@ module IntelligentFoods
 
     def configure
       yield self
-      configure_enviroment
+      configure_environment
     end
 
     def base_auth_url
@@ -37,7 +37,7 @@ module IntelligentFoods
 
     attr_reader :domain, :auth_domain
 
-    def configure_enviroment
+    def configure_environment
       case environment
       when "production"
         @auth_domain = "sunbasket-partner"


### PR DESCRIPTION
 The name of the method was misspelled.
    
This change addresses the need by:
* Fixing the methods spelling.