### PR TITLE
Standardize PR request format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Checklist Before A PR is Raised
+Before raising a PR, you need to check and see if your PR:
+
+- [ ] Meets issue expectations for functionality and implementation (Read the issue cards properly)
+
+- [ ] Has the appropriate test coverage.
+
+- [ ] Has no trailing whitespaces or typos.
+
+- [ ] Has proper indentations.
+
+Refer to the Guides for more information and ensure that your code meets
+the requirements stated there.
+
+
+## Raising a PR
+
+When you're absolutely sure that your code satisfies all the checklist points
+above, please delete the checklist and this paragraph. 
+Raise a PR using the following template as your PR description:
+
+```
+PR Title(this should not be more than 50 characters)
+
+This is a paragraph describing the circumstances that lead to this
+commit being needed. You can think of it like the beginning of the
+body of an email. It's about the "Why" and the intentions behind why we
+needed to made this change. Keep this section wrapped at 72 characters.
+
+This change addresses the need by:
+* List the highlights of the changes made
+
+Resolves #github-issue-number
+```


### PR DESCRIPTION
As a reminder of code quality we want each pull request to have
the same reminder of what a good PR is and to have the same
message structure.

This change addresses that need by:
* Adding PR template to each PR request.