### PR TITLE
Introduce Get Menu Functionality

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -9,7 +9,10 @@ require "intelligent_foods/api_client"
 require "intelligent_foods/authorization"
 require "intelligent_foods/authorization/basic"
 require "intelligent_foods/authorization/bearer"
+require "intelligent_foods/errors"
+require "intelligent_foods/resources/object"
 require "intelligent_foods/resources/menu"
+require "intelligent_foods/resources/menu_item"
 require "intelligent_foods/version"
 
 module IntelligentFoods

--- a/lib/intelligent_foods/api_client.rb
+++ b/lib/intelligent_foods/api_client.rb
@@ -40,7 +40,6 @@ module IntelligentFoods
 
     def assign_body(request:, body:)
       return if body.nil?
-
       request.set_form_data(body)
     end
 

--- a/lib/intelligent_foods/errors.rb
+++ b/lib/intelligent_foods/errors.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class MenuNotFoundError < StandardError; end
+end

--- a/lib/intelligent_foods/resources/menu.rb
+++ b/lib/intelligent_foods/resources/menu.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 module IntelligentFoods
-  class Menu
-    attr_accessor :id
+  class Menu < IntelligentFoods::Object
+    def initialize(args = {})
+      super
+    end
 
-    def initialize(id: nil)
-      @id = id
+    def self.build_from_response(data)
+      menu = build(data)
+      menu.items = MenuItem.build(data[:items])
+      menu
     end
 
     def self.all
@@ -14,9 +18,21 @@ module IntelligentFoods
       client = IntelligentFoods.client
       response = client.execute_request(request: request, uri: uri)
       if response.success?
-        response.data.map { |id| IntelligentFoods::Menu.new(id: id) }
+        response.data.map { |id| Menu.new(id: id) }
       else
         []
+      end
+    end
+
+    def self.find(menu_id)
+      uri = URI("#{IntelligentFoods.base_url}/menu/#{menu_id}")
+      request = Net::HTTP::Get.new(uri)
+      client = IntelligentFoods.client
+      response = client.execute_request(request: request, uri: uri)
+      if response.success?
+        Menu.build_from_response(response.data)
+      else
+        raise MenuNotFoundError
       end
     end
   end

--- a/lib/intelligent_foods/resources/menu_item.rb
+++ b/lib/intelligent_foods/resources/menu_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class MenuItem < IntelligentFoods::Object
+    def initialize(args = {})
+      super
+    end
+  end
+end

--- a/lib/intelligent_foods/resources/object.rb
+++ b/lib/intelligent_foods/resources/object.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class Object < OpenStruct
+    def self.build(data)
+      JSON.parse(data.to_json, object_class: self)
+    end
+  end
+end

--- a/spec/intelligent_foods/resources/menu_spec.rb
+++ b/spec/intelligent_foods/resources/menu_spec.rb
@@ -24,4 +24,55 @@ RSpec.describe IntelligentFoods::Menu do
       end
     end
   end
+
+  describe ".find" do
+    it "returns the menu" do
+      menu_id = "2023-01-01"
+      body = build_menu_response(menu_id: menu_id)
+      response = build_response(body: body)
+      stub_api_response response: response
+
+      result = IntelligentFoods::Menu.find(menu_id)
+
+      expect(result.id).to eq(menu_id)
+    end
+
+    it "assigns correct number of items" do
+      menu_id = "2023-01-01"
+      expected_items_count = 2
+      menu_items = stub_menu_items(number_of_items: expected_items_count)
+      body = build_menu_response(menu_id: menu_id, menu_items: menu_items)
+      response = build_response(body: body)
+      stub_api_response response: response
+      menu = IntelligentFoods::Menu.find(menu_id)
+
+      result = menu.items.size
+
+      expect(result).to eq(expected_items_count)
+    end
+
+    context "the id does not match a menu" do
+      it "raises a IntelligentFoods::MenuNotFound error" do
+        menu_id = "2023-01-01"
+        body = build_error("Menu not found", menu_id)
+        response = build_response(body: body, http_status_code: 400)
+        stub_api_response response: response
+
+        expect {
+          IntelligentFoods::Menu.find(menu_id)
+        }.to raise_error(IntelligentFoods::MenuNotFoundError)
+      end
+    end
+  end
+
+  def build_error(message, menu_id)
+    {
+      type: "https://api.sunbasket.com/partner/problem/menu_not_found",
+      status: 404,
+      title: message,
+      instance: "https://api.sunbasket.com/partner/menu/2020-09-03",
+      detail: message,
+      extra: { menu_id: menu_id },
+    }
+  end
 end

--- a/spec/support/fixtures/menu_response.json
+++ b/spec/support/fixtures/menu_response.json
@@ -1,0 +1,102 @@
+{
+  "id": "2023-05-28",
+  "deadline": "2023-05-24T19:00:00Z",
+  "shipping_fee": 9.99,
+  "items": [
+    {
+      "id": "70f79b16f64b42918b153a2f03b10bea",
+      "sku": "MP0501",
+      "type": "MARKET",
+      "sub_type": "SNACK",
+      "main_category": "SNACK",
+      "sub_category": "NUTS_SEEDS",
+      "name": "Rosemary Maple Sea Salt Almonds (2 count)",
+      "description": "We’re nuts about these savory-sweet almonds. Sourced from family farms in California’s San Joaquin Valley, the almonds are roasted with aromatic rosemary and Vermont pure maple syrup, then finished with a light sprinkling of sea salt. Eat them as snacks, toss into salads, or serve a bowlful at your next party.",
+      "slug": "rosemary-maple-sea-salt-almonds-2-count",
+      "image_id": "ddf22c72-3b56-46a3-b5b9-4c4e724ef474.jpg",
+      "tags": [
+        "NEW"
+      ],
+      "brand_name": "Nuts + Nuts",
+      "quantity": 2,
+      "list_price": 4.99,
+      "unit_size": 2.5,
+      "unit_of_measure": "OZ",
+      "allergens": [
+        {
+          "name": "TREE_NUTS",
+          "source": "almond"
+        }
+      ],
+      "diet_types": [
+        "PALEO",
+        "VEGAN",
+        "VEGETARIAN"
+      ]
+    },
+    {
+      "id": "0a66650369f34f3d9ca1f5609e18fa30",
+      "sku": "S17",
+      "type": "PROTEIN",
+      "protein_type": "FISH",
+      "name": "Alaskan Halibut Fillets (6 oz / serving)",
+      "description": "Firm, meaty Alaskan halibut is one of the world’s premium whitefish. The fact that it maintains its shape helps make it easy to cook, while its sweet, delicate flavor means it goes well with a wide range of seasonings. Our 6-ounce fillets are an excellent source of protein, yet they have just 150 calories with only 2.5 grams of fat.",
+      "slug": "alaskan-halibut-fillets-6-oz--serving",
+      "image_id": "df46d00c-925f-48a2-8047-8738bb9b71a7.jpg",
+      "tags": [
+        "WILD_CAUGHT",
+        "SUSTAINABLY_SOURCED"
+      ],
+      "quantity": 1,
+      "unit_size": 12,
+      "unit_of_measure": "OZ",
+      "allergens": [
+        {
+          "name": "FISH",
+          "source": "halibut"
+        }
+      ]
+    },
+    {
+      "id": "9d5952057ac147339bf6681028e20ed6",
+      "sku": "J246",
+      "type": "MEAL",
+      "sub_type": "FRESH_AND_READY",
+      "main_category": "DINNER",
+      "sub_category": "OVEN_READY",
+      "protein_type": "CHICKEN",
+      "name": "Buffalo grilled chicken breast over cauliflower-potato mash",
+      "description": "For some of us, wings just aren’t big enough. We smother a whole chicken breast in our paleo Buffalo sauce and serve it over a mound of smooth cauliflower mash for a meal made in hot heaven.",
+      "slug": "buffalo-grilled-chicken-breast-over-cauliflower-potato-mash",
+      "image_id": "dcd2b1e9-27dd-465a-9947-7be89fb0bc47.jpg",
+      "tags": [
+        "FRESH_AND_READY"
+      ],
+      "quantity": 1,
+      "list_price": 12.99,
+      "unit_size": 1,
+      "unit_of_measure": "SERVINGS",
+      "calories_per_serving": 380,
+      "allergens": [
+        {
+          "name": "MILK"
+        },
+        {
+          "name": "TREE_NUTS",
+          "source": "almond"
+        }
+      ],
+      "diet_types": [
+        "CARB_CONSCIOUS",
+        "GLUTEN_FREE_FRIENDLY",
+        "KETO_FRIENDLY",
+        "LESS_CALORIES",
+        "NO_ADDED_SUGAR",
+        "PALEO",
+        "PROTEIN_PLUS",
+        "SOY_FREE",
+        "SPICY"
+      ]
+    }
+  ]
+}

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -1,4 +1,6 @@
 module ApiHelper
+  MENU_API_RESPONSE = "spec/support/fixtures/menu_response.json".freeze
+
   def authentication_response(access_token:)
     build_response body: { access_token: access_token }
   end
@@ -29,5 +31,27 @@ module ApiHelper
 
   def build_encoded_token(id:, secret:)
     Base64.strict_encode64("#{id}:#{secret}")
+  end
+
+  def read_menu_api_response
+    JSON.parse(File.read(MENU_API_RESPONSE), symbolize_names: true)
+  end
+
+  def build_menu_response(menu_id: "2023-01-01", menu_items: [])
+    stubbed_response = read_menu_api_response
+    stubbed_response[:id] = menu_id
+    stubbed_response[:items] = menu_items
+    stubbed_response
+  end
+
+  def stubbed_menu_items
+    response = read_menu_api_response
+    response[:items]
+  end
+
+  def stub_menu_items(number_of_items: nil)
+    response = stubbed_menu_items
+    however_many_items = number_of_items || response.size
+    response.first(however_many_items)
   end
 end


### PR DESCRIPTION
The Intelligent Foods Partner API includes a APi endpoint which returns the Menu along with its associated Menu Items. We'd like to incorporate that API call as a feature of this gem.

This change addresses the need by:
* Introducing a new #find method in IntelligentFoods::Menu
* Adding a new resource IntelligentFoods::MenuItem