### PR TITLE
Improve Partner API Authorization 

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -6,6 +6,9 @@ require "net/http"
 require "ostruct"
 
 require "intelligent_foods/api_client"
+require "intelligent_foods/authorization"
+require "intelligent_foods/authorization/basic"
+require "intelligent_foods/authorization/bearer"
 require "intelligent_foods/resources/menu"
 require "intelligent_foods/version"
 

--- a/lib/intelligent_foods/authorization.rb
+++ b/lib/intelligent_foods/authorization.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class Authorization
+    attr_reader :token
+
+    def initialize(token:)
+      @token = token
+    end
+  end
+end

--- a/lib/intelligent_foods/authorization/basic.rb
+++ b/lib/intelligent_foods/authorization/basic.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class Authorization::Basic < Authorization
+    def header
+      "Basic #{token}"
+    end
+
+    def self.factory(client_id:, client_secret:)
+      encoded_token = Base64.strict_encode64("#{client_id}:#{client_secret}")
+      new(token: encoded_token)
+    end
+  end
+end

--- a/lib/intelligent_foods/authorization/bearer.rb
+++ b/lib/intelligent_foods/authorization/bearer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class Authorization::Bearer < Authorization
+    def header
+      "Bearer #{token}"
+    end
+  end
+end

--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe IntelligentFoods::ApiClient do
       expect(client.access_token).to eq(access_token)
     end
 
+    it "sets the authorization basic header" do
+      stub_authentication
+      request = build_stubbed_post
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+      header = "Basic #{build_encoded_token(id: "id", secret: "secret")}"
+
+      client.authenticate!
+
+      expect(request["Authorization"]).to eq(header)
+    end
+
     it "sets the content type header" do
       stub_authentication
       request = build_stubbed_post
@@ -37,12 +48,15 @@ RSpec.describe IntelligentFoods::ApiClient do
   end
 
   describe "#execute_request" do
-    it "sets the authorization header" do
+    it "sets the authorization bearer header" do
       stub_api_response
       request = build_stubbed_post
       uri = URI("https://example.com")
-      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
-      header = "Basic #{build_encoded_token(id: "id", secret: "secret")}"
+      client = IntelligentFoods::ApiClient.new
+      auth = IntelligentFoods::Authorization::Bearer.new(token: "1234")
+      allow(IntelligentFoods::Authorization::Bearer).to receive(:new).
+        and_return(auth)
+      header = "Bearer 1234"
 
       client.execute_request(request: request, uri: uri)
 

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -4,7 +4,7 @@ module ApiHelper
   end
 
   def error_response(message: "Unknown error")
-    build_response body: { errors: [message] }
+    build_response body: { error: message }
   end
 
   def stub_authentication(access_token: "indifferenttoken")


### PR DESCRIPTION
The methods currently used to authenticate against the partner api does not work. This is due to how the Authorization headers are being set for the authentication API calls. Authentication requires "Basic" auth headers, while Partner API calls require "Bearer" headers.

We should fix the broken APi calls and clean up the authorization logic while we're at it.

This change addresses the need by:
* Introducing a BasicAuthorization class
* Introducing a BearerAuthorization class
* Refactoring the ApiClient to make use of the new classes