### PR TITLE
Fix Serialized Order Item Quantity 

### DIFF
--- a/lib/intelligent_foods/serializers/order_item_serializer.rb
+++ b/lib/intelligent_foods/serializers/order_item_serializer.rb
@@ -6,7 +6,7 @@ module IntelligentFoods
       {
         id: id,
         protein_id: protein_id,
-        quantity: 1,
+        quantity: quantity,
       }
     end
   end

--- a/spec/intelligent_foods/resources/order_spec.rb
+++ b/spec/intelligent_foods/resources/order_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe IntelligentFoods::Order do
     it "assigns the order items in the request body" do
       recipient = build(:recipient)
       menu = build(:menu, id: "2023-01-01")
-      order_item = build(:order_item)
+      order_item = build(:order_item, quantity: 2)
       order_item_serialized = IntelligentFoods::OrderItemSerializer.
                               new(order_item).
                               to_json


### PR DESCRIPTION
Currently, the order item quantity was being set to 1 and not taking
into the quantity that is on the actual order item.

This change addresses the need by:
* Updating the OrderItemSerializer to use the order items actual
  quantity value