### PR TITLE
Exclude Blank Recipient Address Values

### DIFF
--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -53,8 +53,6 @@ module IntelligentFoods
         ship_to: ship_to,
         delivery_date: delivery_date,
         items: items_json,
-        callback_url: callback_url,
-        callback_headers: "",
       }
     end
 

--- a/lib/intelligent_foods/serializers/recipient_serializer.rb
+++ b/lib/intelligent_foods/serializers/recipient_serializer.rb
@@ -3,7 +3,7 @@
 module IntelligentFoods
   class RecipientSerializer < SimpleDelegator
     def to_json
-      {
+      recipient_object = {
         name: name,
         street1: street1,
         street2: street2,
@@ -15,6 +15,15 @@ module IntelligentFoods
         phone: phone,
         delivery_instructions: delivery_instructions,
       }
+      remove_blank_values(recipient_object)
+    end
+
+    protected
+
+    def remove_blank_values(obj)
+      obj.delete_if do |_k, v|
+        v.blank?
+      end
     end
   end
 end

--- a/spec/intelligent_foods/resources/order_spec.rb
+++ b/spec/intelligent_foods/resources/order_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe IntelligentFoods::Order do
       expect(result[:ship_to]).to eq(ship_to)
     end
 
+    context "a recipient address value is an empty string" do
+      it "excludes it from the request body" do
+        recipient = build(:recipient, street2: "")
+        menu = build(:menu, id: "2023-01-01")
+        order = IntelligentFoods::Order.new(recipient: recipient, menu: menu)
+        body = build_order_response
+        response = build_response(body: body)
+        stub_api_response response: response
+
+        result = order.request_body[:ship_to]
+
+        expect(result).not_to have_key(:street2)
+      end
+    end
+
     it "assigns the order items in the request body" do
       recipient = build(:recipient)
       menu = build(:menu, id: "2023-01-01")


### PR DESCRIPTION
If the address value is an empty string, or nil, it should not be included in the request body during order creation. The current version of the Intelligent Foods Partner API raises an error if empty strings are included for any address field.

This change addresses the need by:
* Deleting any address keys from the JSON output if blank