### PR TITLE
Switch to Order Item / Protein Item SKU

### DIFF
--- a/lib/intelligent_foods/serializers/order_item_serializer.rb
+++ b/lib/intelligent_foods/serializers/order_item_serializer.rb
@@ -4,8 +4,8 @@ module IntelligentFoods
   class OrderItemSerializer < SimpleDelegator
     def to_json
       {
-        id: id,
-        protein_id: protein_id,
+        sku: sku,
+        protein_sku: protein_sku,
         quantity: quantity,
       }
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,11 +33,11 @@ FactoryBot.define do
   end
 
   factory :order_item, class: "IntelligentFoods::OrderItem" do
-    sequence :id do |n|
-      "d89397e1bad49c3b855df4406e5bf0#{n}"
+    sequence :sku do |n|
+      "IF233#{n}"
     end
-    sequence :protein_id do |n|
-      "c89397e1bad49c3b855df4406e5bf0#{n}"
+    sequence :protein_sku do |n|
+      "IF829#{n}"
     end
     quantity { 1 }
   end


### PR DESCRIPTION
Instead of using the "id" field to determine the order item, and its
selected protein, we should be utilizing the "sku" fields instead as
those would be externally defined.

This change addresses the need by:
* Removing the id and protein_id attributes from the serializer and
  replacing them with sku, and protein_sku