### PR TITLE
Handle Authentication Failures

### DIFF
--- a/lib/intelligent_foods/errors.rb
+++ b/lib/intelligent_foods/errors.rb
@@ -6,4 +6,6 @@ module IntelligentFoods
   class OrderNotCancelledError < StandardError; end
 
   class OrderNotCreatedError < StandardError; end
+
+  class AuthenticationError < StandardError; end
 end

--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe IntelligentFoods::ApiClient do
       expect(http_client).to have_received(:request).with(request).once
     end
 
+    it "parses the response body as JSON" do
+      request = build_stubbed_post
+      http_client = double
+      response = OpenStruct.new(code: 200)
+      stub_api_response response: response, http: http_client
+      uri = URI("https://example.com")
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+      allow(JSON).to receive(:parse)
+
+      client.execute_request(request: request, uri: uri)
+
+      expect(JSON).to have_received(:parse)
+    end
+
     context "the response code is 204" do
       it "does not attempt to parse to response body as JSON" do
         request = build_stubbed_post
@@ -117,6 +131,55 @@ RSpec.describe IntelligentFoods::ApiClient do
         client.execute_request(request: request, uri: uri)
 
         expect(JSON).not_to have_received(:parse)
+      end
+    end
+
+    context "the response code is 401" do
+      it "raises a IntelligentFoods::AuthenticationError" do
+        request = build_stubbed_post
+        http_client = double
+        response = OpenStruct.new(code: 401)
+        stub_api_response response: response, http: http_client
+        uri = URI("https://example.com")
+        client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+
+        expect {
+          client.execute_request(request: request, uri: uri)
+        }.to raise_error(IntelligentFoods::AuthenticationError)
+      end
+
+      it "is not authenticated" do
+        request = build_stubbed_post
+        http_client = double
+        response = OpenStruct.new(code: 401)
+        stub_api_response response: response, http: http_client
+        uri = URI("https://example.com")
+        client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+
+        begin
+          client.execute_request(request: request, uri: uri)
+        rescue IntelligentFoods::AuthenticationError
+          expect(client).not_to be_authenticated
+        end
+      end
+    end
+
+    describe "#authenticated?" do
+      it "is not authenticated" do
+        client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+
+        expect(client).not_to be_authenticated
+      end
+
+      context "the client has been authenticated" do
+        it "is authenticated" do
+          stub_authentication
+          client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+
+          client.authenticate!
+
+          expect(client).to be_authenticated
+        end
       end
     end
   end


### PR DESCRIPTION
If authentication fails due to a access token timeout, we should capture
this and raise a new error. In addition, we should allow consumers to
check if the client has been authenticated, and if authentication fails
ensure this method returns false.

This change addresses the need by:
* Guarding against a 401 (failed authentication) and raising a new error
* Adding a helper method #authenticated?