### PR TITLE
Handle 204 Empty Response

### DIFF
--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -87,5 +87,37 @@ RSpec.describe IntelligentFoods::ApiClient do
 
       expect(http_client).to have_received(:request).with(request).once
     end
+
+    context "the response code is 204" do
+      it "does not attempt to parse to response body as JSON" do
+        request = build_stubbed_post
+        http_client = double
+        response = OpenStruct.new(code: 204)
+        stub_api_response response: response, http: http_client
+        uri = URI("https://example.com")
+        client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+        allow(JSON).to receive(:parse)
+
+        client.execute_request(request: request, uri: uri)
+
+        expect(JSON).not_to have_received(:parse)
+      end
+    end
+
+    context "the response code is 301" do
+      it "does not attempt to parse to response body as JSON" do
+        request = build_stubbed_post
+        http_client = double
+        response = OpenStruct.new(code: 301)
+        stub_api_response response: response, http: http_client
+        uri = URI("https://example.com")
+        client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+        allow(JSON).to receive(:parse)
+
+        client.execute_request(request: request, uri: uri)
+
+        expect(JSON).not_to have_received(:parse)
+      end
+    end
   end
 end

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -15,7 +15,8 @@ module ApiHelper
     stub_api_response response: response
   end
 
-  def stub_api_response(response: OpenStruct.new(body: "{}"), http: double)
+  def stub_api_response(response: OpenStruct.new(body: "{}", code: 200),
+                        http: double)
     allow(Net::HTTP).to receive(:start).and_yield(http)
     allow(http).to receive(:request).and_return(response)
   end


### PR DESCRIPTION
Certain API calls may return a 204 with no response body. If this is the case, we should handle the API response differently and not attempt to parse the body as JSON.

This change addresses the need by:
* Refactoring how #execute_request handles responses