### PR TITLE
Resolve Issue with Class Level Memoization

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -41,7 +41,7 @@ module IntelligentFoods
     end
 
     def client
-      @client ||=
+      @client =
         IntelligentFoods::ApiClient.new(id: client_id, secret: client_secret)
     end
 

--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -22,8 +22,7 @@ module IntelligentFoods
 
     def create!
       uri = URI("#{IntelligentFoods.base_url}/order")
-      request = client.build_request_with_body(uri: uri,
-                                               body: request_body)
+      request = client.build_request_with_body(uri: uri, body: request_body)
       response = client.execute_request(request: request, uri: uri)
       if response.success?
         Order::build_from_response(response.data)
@@ -91,4 +90,3 @@ module IntelligentFoods
     end
   end
 end
-


### PR DESCRIPTION
Memoizing the api client is causing issues when the client_id and
client_secret are changed from one test to another.

You can reproduce the issue by running this command against commit
5cbe9a9

```
bundle exec rspec './spec/intelligent_foods/resources/order_spec.rb[1:1:5:2]' './spec/intelligent_foods_spec.rb[1:5:1]' --seed 34813 --format d
```

This will produce the following error:
```
IntelligentFoods#client returns an instance of the api client
```

When the api client is set up to fail authentication in a test (i.e.
setting the client_id and client_secret to nil), that client was being
memoized at the class level to the IntelligentFoods class.

When the test for IntelligentFoods#clients was run, it was pulling the
existing client held in memory, rather than the new client that was set
up for the test. The new client was not being set on the class due to
the existing memoization.

Removing the memoization solves the issue and I don't believe it will
introduce any significant overhead at this time. If, in  the future, we
want to bring back the memoization, we'll need to have some way of
clearing the client any time the client_id or client_secret is changed.

Separately, this may speak to there being a larger structural issue in
the code, but that would require significantly move investigation and is
not really worth the effort for a pre-v1 release of the gem.

This change addresses the need by:
* Removing the memoization of the api client on the class level .client
  method for the IntelligentFoods class