### PR TITLE
Include Shipment Details When Building Orders

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -19,6 +19,7 @@ require "intelligent_foods/resources/menu_item"
 require "intelligent_foods/serializers/menu_item_serializer"
 require "intelligent_foods/resources/recipient"
 require "intelligent_foods/serializers/recipient_serializer"
+require "intelligent_foods/resources/shipment"
 require "intelligent_foods/version"
 
 module IntelligentFoods

--- a/lib/intelligent_foods/resources/object.rb
+++ b/lib/intelligent_foods/resources/object.rb
@@ -6,6 +6,10 @@ module IntelligentFoods
       JSON.parse(data.to_json, object_class: self)
     end
 
+    def self.build_from_array(array)
+      array.map { |object| build(object) }
+    end
+
     protected
 
     def raise_error(error_class, response)

--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -17,6 +17,7 @@ module IntelligentFoods
       order = build(data)
       order[:items] = OrderItem.build(data[:items])
       order[:ship_to] = Recipient.build(data[:ship_to])
+      order[:shipments] = Shipment.build_from_array(data[:shipments])
       order
     end
 

--- a/lib/intelligent_foods/resources/shipment.rb
+++ b/lib/intelligent_foods/resources/shipment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class Shipment < IntelligentFoods::Object
+    def initialize(args = {})
+      super
+    end
+  end
+end

--- a/spec/intelligent_foods/resources/order_spec.rb
+++ b/spec/intelligent_foods/resources/order_spec.rb
@@ -142,4 +142,16 @@ RSpec.describe IntelligentFoods::Order do
       end
     end
   end
+
+  describe ".build_from_response" do
+    it "assigns the correct number of shipments" do
+      shipment = stub_shipments(number_of_shipments: 1).first
+      data = build_order_response(shipments: [shipment])
+      order = IntelligentFoods::Order.build_from_response(data)
+
+      result = order.shipments.size
+
+      expect(result).to eq(1)
+    end
+  end
 end

--- a/spec/support/fixtures/order_response.json
+++ b/spec/support/fixtures/order_response.json
@@ -59,7 +59,9 @@
       "delivery_status": "UNKNOWN",
       "carrier": "FEDEX",
       "shipment_number": 1,
-      "total_shipments": 2
+      "total_shipments": 2,
+      "tracking_code": "123456789",
+      "tracking_url": "https://fedex.com/track/123456789"
     },
     {
       "id": "4a4f71f35a7145c184d7130cb2107048",
@@ -88,7 +90,9 @@
       "delivery_status": "UNKNOWN",
       "carrier": "FEDEX",
       "shipment_number": 2,
-      "total_shipments": 2
+      "total_shipments": 2,
+      "tracking_code": "123456789",
+      "tracking_url": "https://fedex.com/track/123456789"
     }
   ]
 }

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -50,8 +50,21 @@ module ApiHelper
     stubbed_response
   end
 
-  def build_order_response
-    read_order_api_response
+  def build_order_response(shipments: [])
+    stubbed_response = read_order_api_response
+    stubbed_response[:shipments] = shipments
+    stubbed_response
+  end
+
+  def stubbed_shipments
+    response = read_order_api_response
+    response[:shipments]
+  end
+
+  def stub_shipments(number_of_shipments: nil)
+    response = stubbed_shipments
+    however_many_items = number_of_shipments || response.size
+    response.first(however_many_items)
   end
 
   def stubbed_menu_items


### PR DESCRIPTION
Currently, we do not generate & include shipment details when building an order. The shipment details include the tracking url and tracking number, both are useful to users who are creating orders. We should parse the shipments which are returned by the API and include them in the newly created order.

This change addresses the need by:
* Parsing the response to include shipments when building the order object