### PR TITLE
Update Error Response Structure

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -8,8 +8,8 @@ require "ostruct"
 require "intelligent_foods/api_client"
 require "intelligent_foods/authorization"
 require "intelligent_foods/authorization/basic"
+require "intelligent_foods/resources/api_error"
 require "intelligent_foods/authorization/bearer"
-require "intelligent_foods/errors"
 require "intelligent_foods/resources/object"
 require "intelligent_foods/resources/order"
 require "intelligent_foods/resources/order_item"
@@ -20,6 +20,7 @@ require "intelligent_foods/serializers/menu_item_serializer"
 require "intelligent_foods/resources/recipient"
 require "intelligent_foods/serializers/recipient_serializer"
 require "intelligent_foods/version"
+require "intelligent_foods/errors"
 
 module IntelligentFoods
   class Error < StandardError; end

--- a/lib/intelligent_foods/api_client.rb
+++ b/lib/intelligent_foods/api_client.rb
@@ -60,7 +60,8 @@ module IntelligentFoods
 
     def handle_authentication_error!
       @access_token = nil
-      raise AuthenticationError.new("Authentication failed")
+      raise AuthenticationError.new(status: 401,
+                                    title: "Authentication Failed")
     end
 
     def parse_response_body(response)

--- a/lib/intelligent_foods/errors.rb
+++ b/lib/intelligent_foods/errors.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module IntelligentFoods
-  class MenuNotFoundError < StandardError; end
+  class MenuNotFoundError < ApiError; end
 
-  class OrderNotCancelledError < StandardError; end
+  class OrderNotCancelledError < ApiError; end
 
-  class OrderNotCreatedError < StandardError; end
+  class OrderNotCreatedError < ApiError; end
 
-  class AuthenticationError < StandardError; end
+  class AuthenticationError < ApiError; end
 end

--- a/lib/intelligent_foods/resources/api_error.rb
+++ b/lib/intelligent_foods/resources/api_error.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module IntelligentFoods
+  class ApiError < StandardError
+    attr_reader :status, :title, :details
+
+    def initialize(status:, title:, details: nil)
+      @status = status
+      @title = title
+      @details = details
+      super
+    end
+
+    def message
+      if details.blank?
+        "#{status} - #{title}"
+      else
+        "#{status} #{title} - #{description}"
+      end
+    end
+
+    def self.build(response)
+      data = response.data
+      data => { status:, title:, details: }
+      new(status: status, title: title, details: details)
+    end
+
+    protected
+
+    def description
+      details[:description]
+    end
+  end
+end

--- a/lib/intelligent_foods/resources/menu.rb
+++ b/lib/intelligent_foods/resources/menu.rb
@@ -32,7 +32,7 @@ module IntelligentFoods
       if response.success?
         Menu.build_from_response(response.data)
       else
-        raise MenuNotFoundError
+        raise MenuNotFoundError.build(response)
       end
     end
   end

--- a/lib/intelligent_foods/resources/object.rb
+++ b/lib/intelligent_foods/resources/object.rb
@@ -8,21 +8,8 @@ module IntelligentFoods
 
     protected
 
-    def raise_error(error_class, response)
-      error_message = build_error_message(response)
-      raise error_class.new(error_message)
-    end
-
     def client
       @client ||= IntelligentFoods.client
-    end
-
-    def build_error_message(response)
-      response_body = response.data
-      status_code = response_body[:status]
-      error_title = response_body[:title]
-      error_detail = response_body[:detail]
-      "#{status_code} #{error_title} - #{error_detail}"
     end
   end
 end

--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -28,7 +28,7 @@ module IntelligentFoods
         Order::build_from_response(response.data)
       else
         mark_as_invalid
-        raise_error(OrderNotCreatedError, response)
+        raise OrderNotCreatedError.build(response)
       end
     end
 
@@ -41,7 +41,7 @@ module IntelligentFoods
         self
       else
         mark_as_invalid
-        raise_error(OrderNotCancelledError, response)
+        raise OrderNotCancelledError.build(response)
       end
     end
 

--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe IntelligentFoods::ApiClient do
 
     context "there is an error with the request" do
       it "raises an error" do
-        response = error_response(message: "Could not perform request")
+        response_body = { error: "Could not perform request" }
+        response = error_response(body: response_body)
         stub_api_response response: response
         client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
 

--- a/spec/intelligent_foods/resources/menu_spec.rb
+++ b/spec/intelligent_foods/resources/menu_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe IntelligentFoods::Menu do
     context "the id does not match a menu" do
       it "raises a IntelligentFoods::MenuNotFound error" do
         menu_id = "2023-01-01"
-        body = build_error("Menu not found", menu_id)
-        response = build_response(body: body, http_status_code: 400)
+        response = error_response(message: "Menu not found",
+                                  http_status_code: 400)
         stub_api_response response: response
 
         expect {
@@ -63,16 +63,5 @@ RSpec.describe IntelligentFoods::Menu do
         }.to raise_error(IntelligentFoods::MenuNotFoundError)
       end
     end
-  end
-
-  def build_error(message, menu_id)
-    {
-      type: "https://api.sunbasket.com/partner/problem/menu_not_found",
-      status: 404,
-      title: message,
-      instance: "https://api.sunbasket.com/partner/menu/2020-09-03",
-      detail: message,
-      extra: { menu_id: menu_id },
-    }
   end
 end

--- a/spec/support/fixtures/error_response.json
+++ b/spec/support/fixtures/error_response.json
@@ -1,0 +1,10 @@
+{
+  "status": 400,
+  "title": "Request Validation Error",
+  "detail": "string does not match regex \"^[0-9a-f]",
+  "details": {
+    "description": "string does not match regex \"^[0-9a-f]",
+    "reference_id": 1234,
+    "item_id": 1234
+  }
+}

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -1,13 +1,18 @@
 module ApiHelper
   MENU_API_RESPONSE = "spec/support/fixtures/menu_response.json".freeze
   ORDER_API_RESPONSE = "spec/support/fixtures/order_response.json".freeze
+  ERROR_API_RESPONSE = "spec/support/fixtures/error_response.json".freeze
 
   def authentication_response(access_token:)
     build_response body: { access_token: access_token }
   end
 
-  def error_response(message: "Unknown error", http_status_code: 400)
-    build_response(body: { error: message }, http_status_code: http_status_code)
+  def error_response(message: "Unknown error", http_status_code: 400, body: {})
+    if body.blank?
+      body = read_error_response
+      body[:title] = message
+    end
+    build_response(body: body, http_status_code: http_status_code)
   end
 
   def stub_authentication(access_token: "indifferenttoken")
@@ -33,6 +38,10 @@ module ApiHelper
 
   def build_encoded_token(id:, secret:)
     Base64.strict_encode64("#{id}:#{secret}")
+  end
+
+  def read_error_response
+    parse_json_file(ERROR_API_RESPONSE)
   end
 
   def read_menu_api_response
@@ -70,5 +79,4 @@ module ApiHelper
   def parse_json_file(path)
     JSON.parse(File.read(path), symbolize_names: true)
   end
-
 end


### PR DESCRIPTION
The Partner API is changing the response structure of their errors. We should reflect these changes in the Gem to stay at parity.

Link to Partner API error response structure: https://github.com/Intelligent-Foods/partner-api/pull/297

This change addresses the need by:
* Introducing a ApiError object class
* Parsing the error response body and parsing the new structure to generate better error messages