### PR TITLE
Stringify Order's External ID

### DIFF
--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -48,7 +48,7 @@ module IntelligentFoods
     def request_body
       @request_body ||= {
         menu_id: menu.id,
-        reference_id: external_id,
+        reference_id: external_id.to_s,
         ship_to: ship_to,
         delivery_date: delivery_date,
         items: items_json,

--- a/spec/intelligent_foods/resources/order_spec.rb
+++ b/spec/intelligent_foods/resources/order_spec.rb
@@ -70,6 +70,23 @@ RSpec.describe IntelligentFoods::Order do
       expect(result[:items]).to eq(expected_output)
     end
 
+    it "assigns the reference id as a string in the request body" do
+      recipient = build(:recipient)
+      menu = build(:menu, id: "2023-01-01")
+      order_item = build(:order_item, quantity: 2)
+      order = IntelligentFoods::Order.new(menu: menu,
+                                          recipient: recipient,
+                                          items: [order_item],
+                                          external_id: 1234)
+      body = build_order_response
+      response = build_response(body: body)
+      stub_api_response response: response
+
+      result = order.request_body
+
+      expect(result[:reference_id]).to be_an_instance_of(String)
+    end
+
     context "the response code is not 201" do
       it "raises a OrderNotCreatedError" do
         recipient = build(:recipient)


### PR DESCRIPTION
The Partner API requires the external id of the order to be of type string. We should force this attribute to be a string to ensure that users don't run into any issues with type validations.

Link to documentation: [Partner API Create Order](https://intelligent-foods.github.io/partner-api/redoc#operation/Create_Order_order_post)

This change addresses the need by:
* Stringifying the external id field when building the request body