### PR TITLE
Allow Callback URL and Headers to be Passed In

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 
 group :development, :test do
   gem "factory_bot"
+  gem "json-schema"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.0"
   gem "rubocop", "1.22.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    json-schema (4.3.0)
+      addressable (>= 2.8)
     method_source (1.0.0)
     minitest (5.18.1)
     parallel (1.22.1)
@@ -76,6 +78,7 @@ PLATFORMS
 DEPENDENCIES
   factory_bot
   intelligent_foods!
+  json-schema
   pry (~> 0.14)
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -57,6 +57,8 @@ module IntelligentFoods
         delivery_date: delivery_date,
         items: items_json,
         validation_options: validation_options,
+        callback_url: callback_url,
+        callback_headers: callback_headers,
       }
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,19 @@
 FactoryBot.define do
+  factory :order, class: "IntelligentFoods::Order" do
+    menu
+    recipient
+    delivery_date { Date.today.to_s }
+    items { [build(:order_item)] }
+    sequence :external_id do |n|
+      "d89397e1bad49c3b855df4406e5bf0#{n}"
+    end
+
+    trait :with_callback_attributes do
+      callback_url { "http://test.com/api/callback" }
+      callback_headers { "Auth Bearer sd8ashidjkhj" }
+    end
+  end
+
   factory :recipient, class: "IntelligentFoods::Recipient" do
     name { "First Name" }
     street1 { "123 Main Street" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "factory_bot"
+require "json-schema"
 require "pry"
 require "intelligent_foods"
 require "webmock"

--- a/spec/support/api/schemas/order_with_callback.json
+++ b/spec/support/api/schemas/order_with_callback.json
@@ -1,0 +1,6 @@
+{
+  "type" : "object",
+  "required": ["callback_url", "callback_headers"],
+  "callback_url": { "type": "string" },
+  "callback_headers": { "type": "string" }
+}

--- a/spec/support/api_schema_matcher.rb
+++ b/spec/support/api_schema_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :match_response_schema do |schema|
+  match do |response|
+    schema_directory = "#{Dir.pwd}/spec/support/api/schemas"
+    schema_path = "#{schema_directory}/#{schema}.json"
+    JSON::Validator.validate!(schema_path, response.body, strict: true)
+  end
+end


### PR DESCRIPTION
During order creation, we should include optional params, callback_url and callback_headers. This will allow users to define a callback url which will be sent details of any changes to an order and its shipments.

This change addresses the need by:
* Updating the request body to include passed in callback_url and callback_headers