### PR TITLE
Fix Client Instantiation

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -30,6 +30,7 @@ module IntelligentFoods
 
     def configure
       yield self
+      refresh_client
       configure_environment
     end
 
@@ -42,8 +43,12 @@ module IntelligentFoods
     end
 
     def client
-      @client =
+      @client ||=
         IntelligentFoods::ApiClient.new(id: client_id, secret: client_secret)
+    end
+
+    def refresh_client
+      @client = nil
     end
 
     protected

--- a/spec/intelligent_foods_spec.rb
+++ b/spec/intelligent_foods_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe IntelligentFoods do
   end
 
   describe "#configure" do
+    it "returns a new client with new attributes" do
+      configure_client(id: "abc123", secret: "xyz890")
+
+      IntelligentFoods.configure do |config|
+        config.client_id = "id123"
+        config.client_secret = "secret123"
+      end
+
+      expect(IntelligentFoods.client_id).to eq("id123")
+    end
+
     it "sets the client ID" do
       IntelligentFoods.configure do |config|
         config.client_id = "abc"
@@ -129,15 +140,19 @@ RSpec.describe IntelligentFoods do
 
   describe "#client" do
     it "returns an instance of the api client" do
-      IntelligentFoods.configure do |config|
-        config.client_id = "abc123"
-        config.client_secret = "xyz890"
-      end
-
-      result = IntelligentFoods.client
+      result = configure_client(id: "abc123", secret: "xyz890")
 
       expect(result.id).to eq("abc123")
       expect(result.secret).to eq("xyz890")
     end
   end
+
+  def configure_client(id:, secret:)
+    IntelligentFoods.configure do |config|
+      config.client_id = id
+      config.client_secret = secret
+    end
+    IntelligentFoods.client
+  end
+
 end


### PR DESCRIPTION
Previously, a commit was merged which removed the class level memoization of the client. This solved an issue related to specs, but inherently changed how the IntelligentFoods authentication would work. In order to bring back the original authentication flow, and to fix the issues brought up in the original fix
(89d8fa59f74ded904a22f75db93e7b57bd0c50fd) this PR introduces a new method, #refresh_client, which can be used to create a new client object with a new client_id and client_secret.

This fix was tested using the same seed data as per the original commit:
```
bundle exec rspec
'./spec/intelligent_foods/resources/order_spec.rb[1:1:5:2]'
'./spec/intelligent_foods_spec.rb[1:5:1]' --seed 34813 --format d
```

This change addresses the need by:
* Introducing a #refresh_client method
* Refactoring specs to utilize the new method