### PR TITLE
Add Validation Options when Creating Orders

### DIFF
--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -9,8 +9,12 @@ module IntelligentFoods
     INITIALIZED = "initialized"
     PROCESSED = "processed"
 
-    def initialize(args = {})
+    attr_reader :skip_temperature_check, :skip_address_check
+
+    def initialize(skip_temperature_check: false, skip_address_check: false, **)
       super
+      @skip_temperature_check = skip_temperature_check
+      @skip_address_check = skip_address_check
     end
 
     def self.build_from_response(data)
@@ -52,6 +56,7 @@ module IntelligentFoods
         ship_to: ship_to,
         delivery_date: delivery_date,
         items: items_json,
+        validation_options: validation_options,
       }
     end
 
@@ -87,6 +92,13 @@ module IntelligentFoods
 
     def ship_to
       RecipientSerializer.new(recipient).to_json
+    end
+
+    def validation_options
+      {
+        skip_temperature_check: skip_temperature_check,
+        skip_address_check: skip_address_check,
+      }
     end
   end
 end

--- a/spec/intelligent_foods/resources/order_spec.rb
+++ b/spec/intelligent_foods/resources/order_spec.rb
@@ -118,6 +118,27 @@ RSpec.describe IntelligentFoods::Order do
         expect(order).not_to be_valid
       end
     end
+
+    context "validation options are provided" do
+      it "assigns the validation options in the request body" do
+        recipient = build(:recipient)
+        menu = build(:menu, id: "2023-01-01")
+        order_item = build(:order_item, quantity: 2)
+        order = IntelligentFoods::Order.new(recipient: recipient, menu: menu,
+                                            items: [order_item],
+                                            skip_temperature_check: true)
+        body = build_order_response
+        response = build_response(body: body)
+        stub_api_response response: response
+        expected_output = {
+          skip_temperature_check: true, skip_address_check: false
+        }
+
+        result = order.request_body
+
+        expect(result[:validation_options]).to eq(expected_output)
+      end
+    end
   end
 
   describe "#cancel!" do


### PR DESCRIPTION
Currently, the Partner API supports a 'validation_options' request attribute which can be used to skip certain checks, such as temperature and address. We should allow these two fields to be configurable, but defaulted to false.

This change addresses the need by:
* Including the validations_options attribute in the request body when creating a order
* Defaulting skip_temperature_check and skip_address_check to false, if the user does not provide an override