### PR TITLE
Update Partner API Endpoints

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -34,11 +34,11 @@ module IntelligentFoods
     end
 
     def base_auth_url
-      @base_auth_url = "https://#{auth_domain}.auth.us-west-2.amazoncognito.com"
+      @base_auth_url = "#{base_url}/token"
     end
 
     def base_url
-      @base_url = "https://api.#{domain}.com/partner/v1"
+      @base_url = "https://api.sunbasket.#{tld}/partner/v1"
     end
 
     def client
@@ -48,19 +48,13 @@ module IntelligentFoods
 
     protected
 
-    attr_reader :domain, :auth_domain
+    attr_reader :tld
 
     def configure_environment
-      case environment
-      when "production"
-        @auth_domain = "sunbasket-partner"
-        @domain = "sunbasket"
-      when "staging"
-        @auth_domain = "sunbasket-partner-staging"
-        @domain = "sunbasket-staging"
+      if environment == "production"
+        @tld = "com"
       else
-        @auth_domain = "sunbasket-partner-dev"
-        @domain = "sunbasket-dev"
+        @tld = "dev"
       end
     end
 

--- a/spec/intelligent_foods_spec.rb
+++ b/spec/intelligent_foods_spec.rb
@@ -32,23 +32,12 @@ RSpec.describe IntelligentFoods do
   end
 
   describe "#base_url" do
-    context "environment is preview" do
-      it "returns the correct url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "preview"
-        end
-        preview_url = "https://api.sunbasket-dev.com/partner/v1"
-
-        expect(IntelligentFoods.base_url).to eq(preview_url)
-      end
-    end
-
     context "environment is staging" do
       it "returns the correct url" do
         IntelligentFoods.configure do |config|
           config.environment = "staging"
         end
-        staging_url = "https://api.sunbasket-staging.com/partner/v1"
+        staging_url = "https://api.sunbasket.dev/partner/v1"
 
         expect(IntelligentFoods.base_url).to eq(staging_url)
       end
@@ -70,7 +59,7 @@ RSpec.describe IntelligentFoods do
         IntelligentFoods.configure do |config|
           config.environment = "asdf"
         end
-        preview_url = "https://api.sunbasket-dev.com/partner/v1"
+        preview_url = "https://api.sunbasket.dev/partner/v1"
 
         expect(IntelligentFoods.base_url).to eq(preview_url)
       end
@@ -78,25 +67,13 @@ RSpec.describe IntelligentFoods do
   end
 
   describe "#base_auth_url" do
-    context "environment is preview" do
-      it "returns the correct url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "preview"
-        end
-        preview_url =
-          "https://sunbasket-partner-dev.auth.us-west-2.amazoncognito.com"
-
-        expect(IntelligentFoods.base_auth_url).to eq(preview_url)
-      end
-    end
-
     context "environment is staging" do
       it "returns the correct url" do
         IntelligentFoods.configure do |config|
           config.environment = "staging"
         end
         staging_url =
-          "https://sunbasket-partner-staging.auth.us-west-2.amazoncognito.com"
+          "https://api.sunbasket.dev/partner/v1/token"
 
         expect(IntelligentFoods.base_auth_url).to eq(staging_url)
       end
@@ -108,7 +85,7 @@ RSpec.describe IntelligentFoods do
           config.environment = "production"
         end
         production_url =
-          "https://sunbasket-partner.auth.us-west-2.amazoncognito.com"
+          "https://api.sunbasket.com/partner/v1/token"
 
         expect(IntelligentFoods.base_auth_url).to eq(production_url)
       end
@@ -120,7 +97,7 @@ RSpec.describe IntelligentFoods do
           config.environment = "asdf"
         end
         preview_url =
-          "https://sunbasket-partner-dev.auth.us-west-2.amazoncognito.com"
+          "https://api.sunbasket.dev/partner/v1/token"
 
         expect(IntelligentFoods.base_auth_url).to eq(preview_url)
       end


### PR DESCRIPTION
The endpoints for the authentication and apu have recently been simplified. We should update the gem to use the new endpoints, simplifying the configuration logic.

This change addresses the need by:
* Updating the endpoints