### PR TITLE
Update Partner API Authentication Scheme and API Endpoints

### DIFF
--- a/lib/intelligent_foods.rb
+++ b/lib/intelligent_foods.rb
@@ -34,12 +34,8 @@ module IntelligentFoods
       configure_environment
     end
 
-    def base_auth_url
-      @base_auth_url = "https://#{auth_domain}.auth.us-west-2.amazoncognito.com"
-    end
-
     def base_url
-      @base_url = "https://api.#{domain}.com/partner/v1"
+      @base_url = "https://api.sunbasket.#{tld}/partner/v1"
     end
 
     def client
@@ -53,19 +49,13 @@ module IntelligentFoods
 
     protected
 
-    attr_reader :domain, :auth_domain
+    attr_reader :tld
 
     def configure_environment
-      case environment
-      when "production"
-        @auth_domain = "sunbasket-partner"
-        @domain = "sunbasket"
-      when "staging"
-        @auth_domain = "sunbasket-partner-staging"
-        @domain = "sunbasket-staging"
+      if environment == "production"
+        @tld = "com"
       else
-        @auth_domain = "sunbasket-partner-dev"
-        @domain = "sunbasket-dev"
+        @tld = "dev"
       end
     end
 

--- a/lib/intelligent_foods/api_client.rb
+++ b/lib/intelligent_foods/api_client.rb
@@ -12,23 +12,20 @@ module IntelligentFoods
     end
 
     def authenticate!
-      uri = URI("#{IntelligentFoods.base_auth_url}/oauth2/token")
-      request = Net::HTTP::Post.new(uri)
-      request["content-type"] = "application/x-www-form-urlencoded"
-      body = { "grant_type" => "client_credentials" }
+      uri = URI("#{IntelligentFoods.base_url}/token")
+      body = { client_id: id, client_secret: secret }
+      request = build_request_with_body(uri: uri, body: body)
       authorization = IntelligentFoods::Authorization::Basic.
                       factory(client_id: id, client_secret: secret)
-      response = execute_request(request: request, uri: uri, body: body,
+      response = execute_request(request: request, uri: uri,
                                  authorization: authorization)
       handle_authentication_response(response: response.data)
       self
     end
 
-    def execute_request(request:, uri:, body: nil,
-                        authorization: default_authorization)
+    def execute_request(request:, uri:, authorization: default_authorization)
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         request["Authorization"] = authorization.header
-        assign_body request: request, body: body
         response = http.request(request)
         handle_response(response: response)
       end
@@ -85,11 +82,6 @@ module IntelligentFoods
 
     def authentication_failed?(response_code)
       response_code.to_i == 401
-    end
-
-    def assign_body(request:, body:)
-      return if body.nil?
-      request.set_form_data(body)
     end
 
     def handle_authentication_response(response:)

--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -23,11 +23,22 @@ RSpec.describe IntelligentFoods::ApiClient do
       expect(request["Authorization"]).to eq(header)
     end
 
+    it "includes the client id and client secret in the body" do
+      stub_authentication
+      request = build_stubbed_post
+      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
+      body = { client_id: "id", client_secret: "secret" }
+
+      client.authenticate!
+
+      expect(request.body).to eq(body.to_json)
+    end
+
     it "sets the content type header" do
       stub_authentication
       request = build_stubbed_post
       client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
-      content_type = "application/x-www-form-urlencoded"
+      content_type = "application/json"
 
       client.authenticate!
 
@@ -62,18 +73,6 @@ RSpec.describe IntelligentFoods::ApiClient do
       client.execute_request(request: request, uri: uri)
 
       expect(request["Authorization"]).to eq(header)
-    end
-
-    it "sets the request body" do
-      stub_api_response
-      request = build_stubbed_post
-      uri = URI("https://example.com")
-      client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
-      body = { "grant_type" => "client_credentials" }
-
-      client.execute_request(request: request, uri: uri, body: body)
-
-      expect(request.body).to eq("grant_type=client_credentials")
     end
 
     it "makes the request" do

--- a/spec/intelligent_foods_spec.rb
+++ b/spec/intelligent_foods_spec.rb
@@ -43,23 +43,12 @@ RSpec.describe IntelligentFoods do
   end
 
   describe "#base_url" do
-    context "environment is preview" do
-      it "returns the correct url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "preview"
-        end
-        preview_url = "https://api.sunbasket-dev.com/partner/v1"
-
-        expect(IntelligentFoods.base_url).to eq(preview_url)
-      end
-    end
-
     context "environment is staging" do
       it "returns the correct url" do
         IntelligentFoods.configure do |config|
           config.environment = "staging"
         end
-        staging_url = "https://api.sunbasket-staging.com/partner/v1"
+        staging_url = "https://api.sunbasket.dev/partner/v1"
 
         expect(IntelligentFoods.base_url).to eq(staging_url)
       end
@@ -81,59 +70,9 @@ RSpec.describe IntelligentFoods do
         IntelligentFoods.configure do |config|
           config.environment = "asdf"
         end
-        preview_url = "https://api.sunbasket-dev.com/partner/v1"
+        preview_url = "https://api.sunbasket.dev/partner/v1"
 
         expect(IntelligentFoods.base_url).to eq(preview_url)
-      end
-    end
-  end
-
-  describe "#base_auth_url" do
-    context "environment is preview" do
-      it "returns the correct url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "preview"
-        end
-        preview_url =
-          "https://sunbasket-partner-dev.auth.us-west-2.amazoncognito.com"
-
-        expect(IntelligentFoods.base_auth_url).to eq(preview_url)
-      end
-    end
-
-    context "environment is staging" do
-      it "returns the correct url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "staging"
-        end
-        staging_url =
-          "https://sunbasket-partner-staging.auth.us-west-2.amazoncognito.com"
-
-        expect(IntelligentFoods.base_auth_url).to eq(staging_url)
-      end
-    end
-
-    context "environment is production" do
-      it "returns the correct url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "production"
-        end
-        production_url =
-          "https://sunbasket-partner.auth.us-west-2.amazoncognito.com"
-
-        expect(IntelligentFoods.base_auth_url).to eq(production_url)
-      end
-    end
-
-    context "environment is not any of the above" do
-      it "defaults to the dev url" do
-        IntelligentFoods.configure do |config|
-          config.environment = "asdf"
-        end
-        preview_url =
-          "https://sunbasket-partner-dev.auth.us-west-2.amazoncognito.com"
-
-        expect(IntelligentFoods.base_auth_url).to eq(preview_url)
       end
     end
   end


### PR DESCRIPTION
The method in which the Authentication is performed on the new staging environment differs from the existing environment. In order to be able to use the new staging environment we should update the api endpoint url's (for both staging and prod) and update how Authentication is handled. The new staging environment no-longer requires a Basic header to be passed in, but expects a json encoded request body. We should update this Gem to the new authentication requirements, and update the api endpoints as well.

This change addresses the need by:
* Updating the endpoints
* Updating how the ApiClient authenticates