### PR TITLE
Include Shipment Cancelled Callback

### DIFF
--- a/lib/intelligent_foods/testing/fake/callback.rb
+++ b/lib/intelligent_foods/testing/fake/callback.rb
@@ -54,6 +54,59 @@ module IntelligentFoods
           },
         }
       end
+
+      def self.shipment_cancelled(order_id: SecureRandom.uuid,
+                                  shipment_id: SecureRandom.uuid,
+                                  delivery_date: Date.today,
+                                  carrier: "DEFAULT_CARRIER",
+                                  tracking_url: "https://domain.com/track/1234",
+                                  tracking_code: SecureRandom.uuid)
+        {
+          id: shipment_id,
+          order_id: order_id,
+          reference_id: SecureRandom.uuid,
+          event_type: "SHIPMENT_CANCELLED",
+          shipment_id: shipment_id,
+          data: {
+            id: shipment_id,
+            menu_id: delivery_date.to_date.beginning_of_week.to_s,
+            order_id: order_id,
+            reference_id: SecureRandom.uuid,
+            ship_to: {
+              name: "Full Name",
+              company: "Company Name",
+              street1: "123 Main Street",
+              street2: "",
+              city: "Gotham",
+              state: "NY",
+              zip: "12345",
+              zip4: "",
+              email: "example@domain.com",
+              phone: "5555555555",
+              delivery_instructions: "Default delivery instructions",
+            },
+            delivery_date: delivery_date,
+            items: [
+              {
+                id: "d89397e1bad49c3b855df4406e5bf0d",
+                sku: "MP0001",
+                protein_id: "cca8eedc9842ff9a80e06242fe5a68",
+                protein_sku: "MP0001",
+                quantity: 1,
+              },
+            ],
+            status: "CANCELLED",
+            delivery_status: "PRE_TRANSIT",
+            carrier: carrier,
+            shipment_number: 1,
+            total_shipments: 1,
+            tracking_code: tracking_code,
+            tracking_url: tracking_url,
+            delivery_status_detail: "STATUS_UPDATE",
+            delivery_status_message: "UPDATE_INFO",
+          },
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
The Intelligent Foods Partner API now includes a SHIPMENT_CANCELLED callback event. This event notifies the client that a shipment is no longer being sent to a customer, and is in a cancelled state. We should include this response to allow users to test using a stubbed cancelled callback.

This change addresses the need by:
* Including a SHIPMENT_CANCELLED callback