### PR TITLE
Prepare for Initial Publication

### DIFF
--- a/lib/intelligent_foods/version.rb
+++ b/lib/intelligent_foods/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IntelligentFoods
-  VERSION = "0.0.0"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
We'd like to publish the gem (v.0.1.0) to RubyGems. Before we do so, we
should update the projects version number.

This change addresses the need by:
* Updating the minor version number