### PR TITLE
Refactor Api Client Public Interface Methods

### DIFF
--- a/lib/intelligent_foods/api_client.rb
+++ b/lib/intelligent_foods/api_client.rb
@@ -17,10 +17,28 @@ module IntelligentFoods
       request = build_request_with_body(uri: uri, body: body)
       authorization = IntelligentFoods::Authorization::Basic.
                       factory(client_id: id, client_secret: secret)
-      response = execute_request(request: request, uri: uri,
+      response = execute_request(request: request, uri: request.uri,
                                  authorization: authorization)
       handle_authentication_response(response: response.data)
       self
+    end
+
+    def post(path:, body:)
+      uri = URI(path)
+      request = build_request_with_body(uri: uri, body: body)
+      execute_request(request: request, uri: request.uri)
+    end
+
+    def delete(path:)
+      uri = URI(path)
+      request = Net::HTTP::Delete.new(uri)
+      execute_request(request: request, uri: request.uri)
+    end
+
+    def get(path:)
+      uri = URI(path)
+      request = Net::HTTP::Get.new(uri)
+      execute_request(request: request, uri: request.uri)
     end
 
     def execute_request(request:, uri:, authorization: default_authorization)
@@ -31,13 +49,6 @@ module IntelligentFoods
       end
     end
 
-    def build_request_with_body(uri:, body:)
-      request = Net::HTTP::Post.new(uri)
-      request.body = body.to_json
-      request["content-type"] = "application/json"
-      request
-    end
-
     def authenticated?
       access_token.present?
     end
@@ -45,6 +56,13 @@ module IntelligentFoods
     protected
 
     attr_reader :encoded_token, :request, :response, :uri
+
+    def build_request_with_body(uri:, body:)
+      request = Net::HTTP::Post.new(uri)
+      request.body = body.to_json
+      request["content-type"] = "application/json"
+      request
+    end
 
     def handle_response(response:)
       if authentication_failed?(response.code)

--- a/lib/intelligent_foods/resources/menu.rb
+++ b/lib/intelligent_foods/resources/menu.rb
@@ -13,10 +13,9 @@ module IntelligentFoods
     end
 
     def self.all
-      uri = URI("#{IntelligentFoods.base_url}/menus")
-      request = Net::HTTP::Get.new(uri)
+      path = "#{IntelligentFoods.base_url}/menus"
       client = IntelligentFoods.client
-      response = client.execute_request(request: request, uri: uri)
+      response = client.get(path: path)
       if response.success?
         response.data.map { |id| Menu.new(id: id) }
       else
@@ -25,10 +24,9 @@ module IntelligentFoods
     end
 
     def self.find(menu_id)
-      uri = URI("#{IntelligentFoods.base_url}/menu/#{menu_id}")
-      request = Net::HTTP::Get.new(uri)
+      path = "#{IntelligentFoods.base_url}/menu/#{menu_id}"
       client = IntelligentFoods.client
-      response = client.execute_request(request: request, uri: uri)
+      response = client.get(path: path)
       if response.success?
         Menu.build_from_response(response.data)
       else

--- a/lib/intelligent_foods/resources/order.rb
+++ b/lib/intelligent_foods/resources/order.rb
@@ -25,9 +25,8 @@ module IntelligentFoods
     end
 
     def create!
-      uri = URI("#{IntelligentFoods.base_url}/order")
-      request = client.build_request_with_body(uri: uri, body: request_body)
-      response = client.execute_request(request: request, uri: uri)
+      path = "#{IntelligentFoods.base_url}/order"
+      response = client.post(path: path, body: request_body)
       if response.success?
         Order::build_from_response(response.data)
       else
@@ -37,9 +36,8 @@ module IntelligentFoods
     end
 
     def cancel!
-      uri = URI("#{IntelligentFoods.base_url}/order/#{id}")
-      request = Net::HTTP::Delete.new(uri)
-      response = client.execute_request(request: request, uri: uri)
+      path = "#{IntelligentFoods.base_url}/order/#{id}"
+      response = client.delete(path: path)
       if response.success?
         mark_as_cancelled
         self

--- a/spec/intelligent_foods/api_client_spec.rb
+++ b/spec/intelligent_foods/api_client_spec.rb
@@ -63,14 +63,13 @@ RSpec.describe IntelligentFoods::ApiClient do
     it "sets the authorization bearer header" do
       stub_api_response
       request = build_stubbed_post
-      uri = URI("https://example.com")
       client = IntelligentFoods::ApiClient.new
       auth = IntelligentFoods::Authorization::Bearer.new(token: "1234")
       allow(IntelligentFoods::Authorization::Bearer).to receive(:new).
         and_return(auth)
       header = "Bearer 1234"
 
-      client.execute_request(request: request, uri: uri)
+      client.execute_request(request: request, uri: request.uri)
 
       expect(request["Authorization"]).to eq(header)
     end
@@ -80,10 +79,9 @@ RSpec.describe IntelligentFoods::ApiClient do
       http_client = double
       allow(http_client).to receive(:request)
       stub_api_response http: http_client
-      uri = URI("https://example.com")
       client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
 
-      client.execute_request(request: request, uri: uri)
+      client.execute_request(request: request, uri: request.uri)
 
       expect(http_client).to have_received(:request).with(request).once
     end
@@ -93,11 +91,10 @@ RSpec.describe IntelligentFoods::ApiClient do
       http_client = double
       response = OpenStruct.new(code: 200)
       stub_api_response response: response, http: http_client
-      uri = URI("https://example.com")
       client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
       allow(JSON).to receive(:parse)
 
-      client.execute_request(request: request, uri: uri)
+      client.execute_request(request: request, uri: request.uri)
 
       expect(JSON).to have_received(:parse)
     end
@@ -108,11 +105,10 @@ RSpec.describe IntelligentFoods::ApiClient do
         http_client = double
         response = OpenStruct.new(code: 204)
         stub_api_response response: response, http: http_client
-        uri = URI("https://example.com")
         client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
         allow(JSON).to receive(:parse)
 
-        client.execute_request(request: request, uri: uri)
+        client.execute_request(request: request, uri: request.uri)
 
         expect(JSON).not_to have_received(:parse)
       end
@@ -124,11 +120,10 @@ RSpec.describe IntelligentFoods::ApiClient do
         http_client = double
         response = OpenStruct.new(code: 301)
         stub_api_response response: response, http: http_client
-        uri = URI("https://example.com")
         client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
         allow(JSON).to receive(:parse)
 
-        client.execute_request(request: request, uri: uri)
+        client.execute_request(request: request, uri: request.uri)
 
         expect(JSON).not_to have_received(:parse)
       end
@@ -140,11 +135,10 @@ RSpec.describe IntelligentFoods::ApiClient do
         http_client = double
         response = OpenStruct.new(code: 401)
         stub_api_response response: response, http: http_client
-        uri = URI("https://example.com")
         client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
 
         expect {
-          client.execute_request(request: request, uri: uri)
+          client.execute_request(request: request, uri: request.uri)
         }.to raise_error(IntelligentFoods::AuthenticationError)
       end
 
@@ -153,11 +147,10 @@ RSpec.describe IntelligentFoods::ApiClient do
         http_client = double
         response = OpenStruct.new(code: 401)
         stub_api_response response: response, http: http_client
-        uri = URI("https://example.com")
         client = IntelligentFoods::ApiClient.new(id: "id", secret: "secret")
 
         begin
-          client.execute_request(request: request, uri: uri)
+          client.execute_request(request: request, uri: request.uri)
         rescue IntelligentFoods::AuthenticationError
           expect(client).not_to be_authenticated
         end
@@ -181,6 +174,67 @@ RSpec.describe IntelligentFoods::ApiClient do
           expect(client).to be_authenticated
         end
       end
+    end
+  end
+
+  describe "#post" do
+    it "performs a post request" do
+      stub_api_response
+      body = { test: "yes" }
+      client = IntelligentFoods::ApiClient.new
+      allow(Net::HTTP::Post).to receive(:new).and_call_original
+
+      client.post(path: "http://test.com/orders", body: body)
+
+      expect(Net::HTTP::Post).to have_received(:new)
+    end
+
+    it "assigns a body to the request" do
+      stub_api_response
+      body = { test: "yes" }
+      client = IntelligentFoods::ApiClient.new
+      path = "http://test.com/orders"
+      request = Net::HTTP::Post.new(URI(path))
+      allow(Net::HTTP::Post).to receive(:new).and_return(request)
+
+      client.post(path: path, body: body)
+
+      expect(request.body).to eq(body.to_json)
+    end
+
+    it "executes the request" do
+      stub_api_response
+      body = { test: "yes" }
+      client = IntelligentFoods::ApiClient.new
+      allow(client).to receive(:execute_request).and_call_original
+
+      client.post(path: "http://test.com/orders", body: body)
+
+      expect(client).to have_received(:execute_request)
+    end
+  end
+
+  describe "#delete" do
+    it "performs a delete request" do
+      stub_api_response
+      client = IntelligentFoods::ApiClient.new
+      allow(Net::HTTP::Delete).to receive(:new).and_call_original
+
+      client.delete(path: "http://test.com/orders/1")
+
+      expect(Net::HTTP::Delete).to have_received(:new)
+    end
+  end
+
+  describe "#get" do
+    it "performs a get request" do
+      stub_api_response
+      client = IntelligentFoods::ApiClient.new
+      allow(Net::HTTP::Get).to receive(:new).and_call_original
+
+      client.get(path: "http://test.com/orders/1")
+
+      expect(Net::HTTP::Get).to have_received(:new)
     end
   end
 end

--- a/spec/intelligent_foods/resources/order_spec.rb
+++ b/spec/intelligent_foods/resources/order_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe IntelligentFoods::Order do
         callback_url = "https://api.domain.com/callback"
         order = build(:order, callback_url: callback_url)
         stub_api_response
-        request = Net::HTTP::Post.new("http://domain.com")
+        request = Net::HTTP::Post.new(URI("http://domain.com"))
         allow(Net::HTTP::Post).to receive(:new).and_return(request)
 
         order.create!

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -26,8 +26,8 @@ module ApiHelper
     allow(http).to receive(:request).and_return(response)
   end
 
-  def build_stubbed_post(url: "example.com")
-    request = Net::HTTP::Post.new(url)
+  def build_stubbed_post(url: "http://example.com")
+    request = Net::HTTP::Post.new(URI(url))
     allow(Net::HTTP::Post).to receive(:new).and_return(request)
     request
   end


### PR DESCRIPTION
Currently, the API client's public methods are vague and too verbose. Instead of pushing the business logic into the resources, the ApiClient class should expose simple, readable methods which act as a wrapper to the HTTP library.

This change addresses the need by:
* Refactoring the ApiClient class, exposing Post, Get, and Delete methods
* Refactoring the Menu and Order classes to use the new ApiClient public interface