### PR TITLE
Update Public Method of Menu Fake

### DIFF
--- a/lib/intelligent_foods/testing/fake.rb
+++ b/lib/intelligent_foods/testing/fake.rb
@@ -19,7 +19,7 @@ module IntelligentFoods
                          shipping_fee: 9.99, items: items)
         end
 
-        def self.find(id)
+        def self.retrieve(id)
           items = [Fake::MenuItem.create]
           OpenStruct.new(id: id, deadline: Time.zone.now,
                          shipping_fee: 9.99, items: items)


### PR DESCRIPTION
The public methods of our resources have been recently updated. Instead of #find, the resources will now use #retrieve. The IntelligentFoods::Testing::Fake class should also be updated to reflect those changes.

This change addresses the need by:
* Updating the Menu fake's public methods