### PR TITLE
Add InventoryLevel Fake

### DIFF
--- a/lib/intelligent_foods/testing/fake.rb
+++ b/lib/intelligent_foods/testing/fake.rb
@@ -5,6 +5,23 @@ module IntelligentFoods
     class Fake
       def self.configure(*); end
 
+      class DistributionCenterInventory
+        def self.create(name: "WEST_COAST", quantity: 100)
+          OpenStruct.new(distribution_center: name, quantity: quantity)
+        end
+      end
+
+      class InventoryLevel
+        def self.create(sku: "SKU1", date: Date.today.to_s,
+                        dc_inventory: [DistributionCenterInventory.create])
+          inventory_level = OpenStruct.new(
+            date: date,
+            inventory_by_distribution_center: dc_inventory
+          )
+          OpenStruct.new(sku: sku, inventory_levels: [inventory_level])
+        end
+      end
+
       class MenuItem
         def self.create(id: SecureRandom.uuid, sku: "SKU1",
                         name: "FakeMenuItem")


### PR DESCRIPTION
With the recent addition of the InventoryLevel resource, our clients should also be given a fake which could be used to stub the resource in their tests.

This change addresses the need by:
* Adding a InventoryLevel fake