### PR TITLE
Fix Console Script

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,15 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "irb"
 require "bundler/setup"
 require "bls/core"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
 IRB.start(__FILE__)


### PR DESCRIPTION
Running `bin/console` would result in quite a few ruby libs from being undefined (SimpleDelegator for example), raising an error. This prevented the console from starting a new session.

This change addresses the need by:
* Updating the load order of libs