### PR TITLE
Update Inventory Level Resource

### DIFF
--- a/lib/bls/core/resources/inventory_level.rb
+++ b/lib/bls/core/resources/inventory_level.rb
@@ -11,12 +11,21 @@ module Bls
         "#{api.base_url}/products/inventory-levels"
       end
 
+      def to_json
+        {
+          sku: sku,
+          date: date,
+          distribution_center: distribution_center,
+          quantity: quantity
+        }
+      end
+
       def self.retrieve_all
         resource = new
         api_client = resource.client
         response = api_client.get(path: resource.resources_path)
         if response.success?
-          response.data[:products].map { |product| build(product) }
+          response.data[:inventory].map { |inventory| build(inventory) }
         else
           raise ResourceRetrievalError.build(response)
         end

--- a/lib/bls/core/testing/fake.rb
+++ b/lib/bls/core/testing/fake.rb
@@ -6,20 +6,25 @@ module Bls
       class Fake
         def self.configure(*); end
 
-        class DistributionCenterInventory
-          def self.create(name: "WEST_COAST", quantity: 100)
-            OpenStruct.new(distribution_center: name, quantity: quantity)
-          end
-        end
-
         class InventoryLevel
           def self.create(sku: "SKU1", date: Date.today.to_s,
-                          dc_inventory: [DistributionCenterInventory.create])
-            inventory_level = OpenStruct.new(
-              date: date,
-              inventory_by_distribution_center: dc_inventory
-            )
-            OpenStruct.new(sku: sku, inventory_levels: [inventory_level])
+                          distribution_center_name: "WEST_COAST",
+                          quantity: 100)
+            OpenStruct.new(sku: sku, date: date,
+                           distribution_center: distribution_center_name,
+                           quantity: quantity)
+          end
+
+          def self.serialize(sku: "SKU1", date: Date.today.to_s,
+                             distribution_center_name: "WEST_COAST",
+                             quantity: 100)
+            create(sku: sku, date: date,
+                   distribution_center_name: distribution_center_name,
+                   quantity: quantity).to_h
+          end
+
+          def self.retrieve_all
+            [Fake::InventoryLevel.create]
           end
         end
 

--- a/spec/core/resources/inventory_level_spec.rb
+++ b/spec/core/resources/inventory_level_spec.rb
@@ -11,7 +11,26 @@ RSpec.describe Bls::Core::InventoryLevel do
 
       result = Bls::Core::InventoryLevel.retrieve_all
 
-      expect(result.map(&:product_code)).to match_array(product_id)
+      expect(result.map(&:sku)).to match_array(product_id)
+    end
+  end
+
+  describe "#to_json" do
+    it "returns a serialized inventory level" do
+      level = Bls::Core::InventoryLevel.new(sku: "BLS123",
+                                            date: "2026-01-01",
+                                            distribution_center: "WEST_COAST",
+                                            quantity: 100)
+      serialized_level = {
+        sku: "BLS123",
+        date: "2026-01-01",
+        distribution_center: "WEST_COAST",
+        quantity: 100,
+      }
+
+      result = level.to_json
+
+      expect(result).to eq(serialized_level)
     end
   end
 end

--- a/spec/support/fixtures/inventory_levels_response.json
+++ b/spec/support/fixtures/inventory_levels_response.json
@@ -1,18 +1,10 @@
 {
-  "products": [
+  "inventory": [
     {
-      "product_code": "MP0527",
-      "inventory_levels": [
-        {
-          "date": "2020-04-19",
-          "inventory_by_distribution_center": [
-            {
-              "distribution_center": "WEST_COAST",
-              "quantity": "2.0"
-            }
-          ]
-        }
-      ]
+      "sku": "MP0527",
+      "date": "2020-04-19",
+      "distribution_center": "WEST_COAST",
+      "quantity": 2
     }
   ],
   "missing_product_codes": [


### PR DESCRIPTION
The inventory level structure has changed, and the API will now be
returning a simplified, flatter response structure. Due to this, the
InventoryLevel object needs to be refactored to take into account the
new response structure and the new top-level key.

This change addresses the need by:
* Updating the Inventory Level response fake
* Updating Inventory Level to account for the new key name